### PR TITLE
fix: allow an opaque response in ping()

### DIFF
--- a/src/iHttpConnection.ts
+++ b/src/iHttpConnection.ts
@@ -120,7 +120,7 @@ export class IHTTPConnection extends IMeshDevice {
 
     let pingSuccessful = false;
 
-    await fetch(`${this.url}/hotspot-detect.html`, { signal })
+    await fetch(`${this.url}/hotspot-detect.html`, { signal, mode: 'no-cors' })
       .then(() => {
         pingSuccessful = true;
         this.updateDeviceStatus({


### PR DESCRIPTION
When using the library to connect to a Meshtastic radio, the Ping method attempts to fetch from `hotspot-detect.html`. Unlike the `/api` endpoints, the Meshtastic device HTTP server doesn't set any CORS headers on the `hotspot-detect.html` response. As a result, the PING will fail:

![PING failure in Chrome Inspector](https://user-images.githubusercontent.com/3635991/210225533-6dd80a83-6e6c-403d-ac6b-f0f196f72089.png)

Since meshtasticjs doesn't actually check the response from the server in this instance - just needs the request to go through, we can use `mode: no-cors` and allow this `fetch` to resolve successfully.
