### PR TITLE
Don't request response for text message

### DIFF
--- a/src/iMeshDevice.ts
+++ b/src/iMeshDevice.ts
@@ -110,7 +110,7 @@ export abstract class IMeshDevice {
       destination ?? "broadcast",
       channel,
       wantAck,
-      true,
+      false,
       true
     );
   }


### PR DESCRIPTION
This PR changes the exported `sendText` function to not set the `want_response` field to `true` on text packets. If a response is requested, the receiving device will respond with a `NoResponse` routing error, which will also fail to receive the message.

> This is the result of a discussion in the `#web` channel of the Meshtastic Discord server.