### PR TITLE
Bump Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,19 +36,19 @@
     "url": "https://github.com/meshtastic/js.git"
   },
   "dependencies": {
-    "@buf/meshtastic_protobufs.bufbuild_es": "1.4.2-20231115125959-252a144b0286.1",
-    "@bufbuild/protobuf": "^1.4.2",
+    "@buf/meshtastic_protobufs.bufbuild_es": "1.5.1-20231206215336-8002ce9b3c7a.1",
+    "@bufbuild/protobuf": "^1.5.1",
     "crc": "^4.3.2",
     "sub-events": "^1.9.0",
     "tslib": "^2.6.2",
     "tslog": "^4.9.2"
   },
   "devDependencies": {
-    "@types/node": "^20.9.0",
+    "@types/node": "^20.10.4",
     "@types/w3c-web-serial": "^1.0.6",
     "@types/web-bluetooth": "^0.0.20",
     "biome": "^0.3.3",
-    "typedoc": "^0.25.3",
-    "typescript": "^5.2.2"
+    "typedoc": "^0.25.4",
+    "typescript": "^5.3.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,11 +6,11 @@ settings:
 
 dependencies:
   '@buf/meshtastic_protobufs.bufbuild_es':
-    specifier: 1.4.2-20231115125959-252a144b0286.1
-    version: 1.4.2-20231115125959-252a144b0286.1(@bufbuild/protobuf@1.4.2)
+    specifier: 1.5.1-20231206215336-8002ce9b3c7a.1
+    version: 1.5.1-20231206215336-8002ce9b3c7a.1(@bufbuild/protobuf@1.5.1)
   '@bufbuild/protobuf':
-    specifier: ^1.4.2
-    version: 1.4.2
+    specifier: ^1.5.1
+    version: 1.5.1
   crc:
     specifier: ^4.3.2
     version: 4.3.2
@@ -26,8 +26,8 @@ dependencies:
 
 devDependencies:
   '@types/node':
-    specifier: ^20.9.0
-    version: 20.9.0
+    specifier: ^20.10.4
+    version: 20.10.4
   '@types/w3c-web-serial':
     specifier: ^1.0.6
     version: 1.0.6
@@ -38,28 +38,28 @@ devDependencies:
     specifier: ^0.3.3
     version: 0.3.3
   typedoc:
-    specifier: ^0.25.3
-    version: 0.25.3(typescript@5.2.2)
+    specifier: ^0.25.4
+    version: 0.25.4(typescript@5.3.3)
   typescript:
-    specifier: ^5.2.2
-    version: 5.2.2
+    specifier: ^5.3.3
+    version: 5.3.3
 
 packages:
 
-  /@buf/meshtastic_protobufs.bufbuild_es@1.4.2-20231115125959-252a144b0286.1(@bufbuild/protobuf@1.4.2):
-    resolution: {registry: https://buf.build/gen/npm/v1, tarball: https://buf.build/gen/npm/v1/@buf/meshtastic_protobufs.bufbuild_es/-/meshtastic_protobufs.bufbuild_es-1.4.2-20231115125959-252a144b0286.1.tgz}
+  /@buf/meshtastic_protobufs.bufbuild_es@1.5.1-20231206215336-8002ce9b3c7a.1(@bufbuild/protobuf@1.5.1):
+    resolution: {tarball: https://buf.build/gen/npm/v1/@buf/meshtastic_protobufs.bufbuild_es/-/meshtastic_protobufs.bufbuild_es-1.5.1-20231206215336-8002ce9b3c7a.1.tgz}
     peerDependencies:
-      '@bufbuild/protobuf': ^1.4.2
+      '@bufbuild/protobuf': ^1.5.1
     dependencies:
-      '@bufbuild/protobuf': 1.4.2
+      '@bufbuild/protobuf': 1.5.1
     dev: false
 
-  /@bufbuild/protobuf@1.4.2:
-    resolution: {integrity: sha512-JyEH8Z+OD5Sc2opSg86qMHn1EM1Sa+zj/Tc0ovxdwk56ByVNONJSabuCUbLQp+eKN3rWNfrho0X+3SEqEPXIow==}
+  /@bufbuild/protobuf@1.5.1:
+    resolution: {integrity: sha512-LX+MeB1AzlbqgJXkq83lilQpLGnPvsAMj7SH8KtJAmQfBc55ee78Stxuff/HMw0xLMYJN3P1FBh5TENgjJof1w==}
     dev: false
 
-  /@types/node@20.9.0:
-    resolution: {integrity: sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==}
+  /@types/node@20.10.4:
+    resolution: {integrity: sha512-D08YG6rr8X90YB56tSIuBaddy/UXAA9RKJoFvrsnogAum/0pmjkgi4+2nx96A330FmioegBWmEYQ+syqCFaveg==}
     dependencies:
       undici-types: 5.26.5
     dev: true
@@ -679,8 +679,8 @@ packages:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
     dev: true
 
-  /shiki@0.14.5:
-    resolution: {integrity: sha512-1gCAYOcmCFONmErGTrS1fjzJLA7MGZmKzrBNX7apqSwhyITJg2O102uFzXUeBxNnEkDA9vHIKLyeKq0V083vIw==}
+  /shiki@0.14.6:
+    resolution: {integrity: sha512-R4koBBlQP33cC8cpzX0hAoOURBHJILp4Aaduh2eYi+Vj8ZBqtK/5SWNEHBS3qwUMu8dqOtI/ftno3ESfNeVW9g==}
     dependencies:
       ansi-sequence-parser: 1.1.1
       jsonc-parser: 3.2.0
@@ -774,22 +774,22 @@ packages:
     resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
     dev: true
 
-  /typedoc@0.25.3(typescript@5.2.2):
-    resolution: {integrity: sha512-Ow8Bo7uY1Lwy7GTmphRIMEo6IOZ+yYUyrc8n5KXIZg1svpqhZSWgni2ZrDhe+wLosFS8yswowUzljTAV/3jmWw==}
+  /typedoc@0.25.4(typescript@5.3.3):
+    resolution: {integrity: sha512-Du9ImmpBCw54bX275yJrxPVnjdIyJO/84co0/L9mwe0R3G4FSR6rQ09AlXVRvZEGMUg09+z/usc8mgygQ1aidA==}
     engines: {node: '>= 16'}
     hasBin: true
     peerDependencies:
-      typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x
+      typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x
     dependencies:
       lunr: 2.3.9
       marked: 4.3.0
       minimatch: 9.0.3
-      shiki: 0.14.5
-      typescript: 5.2.2
+      shiki: 0.14.6
+      typescript: 5.3.3
     dev: true
 
-  /typescript@5.2.2:
-    resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
+  /typescript@5.3.3:
+    resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true

--- a/src/meshDevice.ts
+++ b/src/meshDevice.ts
@@ -1,6 +1,6 @@
 import { Logger } from "tslog";
 
-import { broadcastNum, minFwVer } from "./constants.js";
+import { broadcastNum } from "./constants.js";
 import { Protobuf, Types } from "./index.js";
 import { EventSystem } from "./utils/eventSystem.js";
 import { Queue } from "./utils/queue.js";
@@ -827,33 +827,6 @@ export abstract class MeshDevice {
         void this.XModem.handlePacket(decodedMessage.payloadVariant.value);
         break;
 
-      case "metadata":
-        if (
-          parseFloat(decodedMessage.payloadVariant.value.firmwareVersion) <
-          minFwVer
-        ) {
-          this.log.fatal(
-            Types.Emitter[Types.Emitter.handleFromRadio],
-            `Device firmware outdated. Min supported: ${minFwVer} got : ${decodedMessage.payloadVariant.value.firmwareVersion}`,
-          );
-        }
-        this.log.debug(
-          Types.Emitter[Types.Emitter.getMetadata],
-          "🏷️ Recieved metadata packet",
-        );
-
-        this.events.onDeviceMetadataPacket.emit({
-          id: decodedMessage.id,
-          rxTime: new Date(),
-          from: 0,
-          to: 0,
-          type: "direct",
-          channel: Types.ChannelNumber.PRIMARY,
-          data: decodedMessage.payloadVariant.value,
-        });
-        break;
-      case "mqttClientProxyMessage":
-        break;
       default:
         throw new Error(`Unhandled case ${decodedMessage.payloadVariant.case}`);
     }


### PR DESCRIPTION
This PR bumps the following dependencies:
- @buf/meshtastic_protobufs.bufbuild_es
    `1.4.2-20231115125959-252a144b0286.1` -> `1.5.1-20231206215336-8002ce9b3c7a.1`
- @bufbuild/protobuf
    `^1.4.2` -> `^1.5.1`
- @types/node
    `^20.9.0` -> `^20.10.4`
- typedoc
    `^0.25.3` -> `^0.25.4`
- typescript 
    `^5.2.2` -> `^5.3.3`

Additionally it removes the `metadata` payload variant case as it has been removed.