### PR TITLE
auto-refresh from radio at interval

### DIFF
--- a/src/adapters/bleConnection.ts
+++ b/src/adapters/bleConnection.ts
@@ -34,6 +34,8 @@ export class BleConnection extends MeshDevice {
   /** Short Description */
   private fromNumCharacteristic: BluetoothRemoteGATTCharacteristic | undefined;
 
+  private timerUpdateFromRadio: NodeJS.Timeout | null = null;
+
   constructor(configId?: number) {
     super(configId);
 
@@ -183,6 +185,9 @@ export class BleConnection extends MeshDevice {
     void this.configure().catch(() => {
       // TODO: FIX, workaround for `wantConfigId` not getting acks.
     });
+
+
+    this.timerUpdateFromRadio = setInterval(() => this.readFromRadio(), 1000);
   }
 
   /** Disconnects from the Meshtastic device */
@@ -190,6 +195,8 @@ export class BleConnection extends MeshDevice {
     this.device?.gatt?.disconnect();
     this.updateDeviceStatus(Types.DeviceStatusEnum.DEVICE_DISCONNECTED);
     this.complete();
+    clearInterval(this.timerUpdateFromRadio!);
+    this.timerUpdateFromRadio = null;
   }
 
   /**


### PR DESCRIPTION
This PR solves the problem where the application does not constantly update from the radio. For example, this creates a problem in the Meshtastic Web app where you can't receive messages and you have to first send a message in order to display new messages.

This change makes readFromRadio be called at 1-second intervals, so that the application will refresh every second.

n.b. This works for Bluetooth connection only.