### PR TITLE
Only warn when a message's payloadVariant is unrecognized, rather than error.

### DIFF
--- a/src/meshDevice.ts
+++ b/src/meshDevice.ts
@@ -867,7 +867,10 @@ export abstract class MeshDevice {
         break;
       }
       default: {
-        throw new Error(`Unhandled case ${decodedMessage.payloadVariant.case}`);
+        this.log.warn(
+          Types.Emitter[Types.Emitter.HandleFromRadio],
+          `⚠️ Unhandled payload variant: ${decodedMessage.payloadVariant.case}`,
+        );
       }
     }
   }


### PR DESCRIPTION
This was discussed a bit in discord, around the vicinity of https://discord.com/channels/867578229534359593/871553714782081024/1218233913311232041

short version there is that someone was seeing log messages of "ReadFromRadio ❌ Unhandled case 71". 71 is for NeighborInfo packets which the JS doesn't know how to do anything with (which is maybe a separate issue). Upon discussion @ajmcquilkin and I were thinking this seemed more warning-level than error-level.

Hopefully I've switched it to warning correctly, first JS PR obviously!