### PR TITLE
updated package version

### DIFF
--- a/packages/core/deno.json
+++ b/packages/core/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshtastic/core",
-  "version": "2.6.0",
+  "version": "2.6.2",
   "exports": {
     ".": "./mod.ts"
   },


### PR DESCRIPTION
Update core package version to match protobuf version, this will (hopefully) expose the latest protobuf dependency as a result of being merged and published to JSR registry. 