### PR TITLE
Add event for canned message response 🥫

### DIFF
--- a/packages/core/src/meshDevice.ts
+++ b/packages/core/src/meshDevice.ts
@@ -989,6 +989,18 @@ export class MeshDevice {
             });
             break;
           }
+          case "getCannedMessageModuleMessagesResponse": {
+            this.log.debug(
+              Emitter[Emitter.GetMetadata],
+              `🥫 Received CannedMessage Module Messages response packet`,
+            );
+
+            this.events.onCannedMessageModulePacket.dispatch({
+              ...packetMetadata,
+              data: adminMessage.payloadVariant.value,
+            });
+            break;
+          }
           default: {
             this.log.error(
               Emitter[Emitter.HandleMeshPacket],

--- a/packages/core/src/utils/eventSystem.ts
+++ b/packages/core/src/utils/eventSystem.ts
@@ -178,6 +178,17 @@ export class EventSystem {
   >();
 
   /**
+   * Fires when the device receives a Canned Message Module message packet
+   *
+   * @event onCannedMessageModulePacket
+   */
+    public readonly onCannedMessageModulePacket: SimpleEventDispatcher<
+    PacketMetadata<string>
+  > = new SimpleEventDispatcher<
+    PacketMetadata<string>
+  >();
+
+  /**
    * Fires when a new MeshPacket message containing a Waypoint packet has been
    * received from device
    *


### PR DESCRIPTION
This small PR adds an event for the admin message `getCannedMessageModuleMessagesResponse`, sent when the device replies with the configured canned messages.

This is not tested - spent a few hours struggling with Deno in an attempt to load a local module without success.