### PR TITLE
Fix Bluetooth connection initialization

### DIFF
--- a/packages/transport-web-bluetooth/deno.json
+++ b/packages/transport-web-bluetooth/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshtastic/transport-web-bluetooth",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "exports": {
     ".": "./mod.ts"
   },


### PR DESCRIPTION
Our previous BLE transport polled the device every 1s, which was changed to an event driven approach in the recent refactoring. The event driven approach did however not work as expected, since the first read needs to be triggered manually by the client. 

As a result of this, meshtastic/web is still dependent on old meshtastic/js package instead of using the new, refactored package meshtastic/transport-web-bluetooth.


This PR adds a _isFirstWrite flag to trigger a one‐time “first read” after sending the initial wantConfigId packet. This is a mirror of the iOS logic which issues a one‐off read immediately after sending its “wantConfigId” request. 

Subsequent reads are triggered as they should by the event.


Testing have been done on a nRF based device on firmware 2.6.4 together with modified web client which uses the new package.