### PR TITLE
Fix JSR publishing workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,4 +28,4 @@ jobs:
         run: deno lint
 
       - name: Publish to JSR
-        run: deno publish
+        run: npx jsr publish


### PR DESCRIPTION
Using JSR.io documented method to publish packages to the JSR repository. 